### PR TITLE
Error: Cannot find module 'uberscore'

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "grunt": "~0.4.1",
     "mocha": "~1.7.2",
     "underscore": "*",
-    "uberscore": "0.0.10",
     "expect.js": "~0.2.0",
     "grunt-simple-mocha": "~0.4.0"
 
   },
   "dependencies": {
+    "uberscore": "0.0.10",
     "urequire": "0.4.x"
   }
 }


### PR DESCRIPTION
Hey there, so `uberscore` was added as a devDependency in [this commit](https://github.com/aearly/grunt-urequire/commit/726219ba4c8d87d92291c325be5a367c85927ef8#L1R51).  But it's also being used in the task [here](https://github.com/aearly/grunt-urequire/commit/726219ba4c8d87d92291c325be5a367c85927ef8#L2R6).  Since it's just a devDependency, it doesn't get installed for someone using it in like a package.json file.  I suppose it could be just put into "dependencies" and solve this.
